### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Activate virtual environment
+        run: |
+          uv venv
+          source .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
+
       - name: Install dependencies
         run: make init
 
@@ -37,6 +46,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Activate virtual environment
+        run: |
+          uv venv
+          source .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
 
       - name: Install dependencies
         run: make init

--- a/l2m2/model_info.py
+++ b/l2m2/model_info.py
@@ -1,9 +1,14 @@
 """Information about models and providers supported by L2M2."""
 
-from typing import Dict, Union, Any
-from typing_extensions import TypedDict, NotRequired, TypeVar, Generic, Literal
-from enum import Enum
+from typing import Any, Dict, Union, Literal, TypedDict
 import sys
+
+PROVIDER_DEFAULT: Literal["<<PROVIDER_DEFAULT>>"] = "<<PROVIDER_DEFAULT>>"
+
+API_KEY = "<<API_KEY>>"
+MODEL_ID = "<<MODEL_ID>>"
+
+INF: int = sys.maxsize
 
 
 class ProviderEntry(TypedDict):
@@ -13,39 +18,32 @@ class ProviderEntry(TypedDict):
     headers: Dict[str, str]
 
 
-T = TypeVar("T")
-
-Marker = Enum("Marker", {"PROVIDER_DEFAULT": "<<PROVIDER_DEFAULT>>"})
-PROVIDER_DEFAULT: Marker = Marker.PROVIDER_DEFAULT
-
-API_KEY = "<<API_KEY>>"
-MODEL_ID = "<<MODEL_ID>>"
+class ParamOptionalFields(TypedDict, total=False):
+    custom_key: str
 
 
-class Param(TypedDict, Generic[T]):
-    custom_key: NotRequired[str]
-    default: Union[T, Literal[Marker.PROVIDER_DEFAULT]]
-    max: T
+class FloatParam(ParamOptionalFields):
+    default: Union[float, Literal["<<PROVIDER_DEFAULT>>"]]
+    max: float
+
+
+class IntParam(ParamOptionalFields):
+    default: Union[int, Literal["<<PROVIDER_DEFAULT>>"]]
+    max: int
+
+
+ParamName = Literal["temperature", "max_tokens"]
 
 
 class ModelParams(TypedDict):
-    temperature: Param[float]
-    max_tokens: Param[int]
-
-
-ParamName = Literal[
-    "temperature",
-    "max_tokens",
-]
+    temperature: FloatParam
+    max_tokens: IntParam
 
 
 class ModelEntry(TypedDict):
     model_id: str
     params: ModelParams
     extras: Dict[str, Any]
-
-
-INF: int = sys.maxsize
 
 
 PROVIDER_INFO: Dict[str, ProviderEntry] = {
@@ -127,10 +125,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "gpt-4o-2024-11-20",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -144,10 +139,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "gpt-4o-mini-2024-07-18",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -161,10 +153,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "o1",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -178,10 +167,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "o1-preview",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -195,10 +181,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "o1-mini",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -212,10 +195,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "gpt-4-turbo-2024-04-09",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -229,10 +209,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "openai": {
             "model_id": "gpt-3.5-turbo-0125",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_completion_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -246,14 +223,10 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "google": {
             "model_id": "gemini-2.0-flash-exp",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_output_tokens",
                     "default": PROVIDER_DEFAULT,
-                    # https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
                     "max": 8192,
                 },
             },
@@ -264,14 +237,10 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "google": {
             "model_id": "gemini-1.5-flash",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_output_tokens",
                     "default": PROVIDER_DEFAULT,
-                    # https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
                     "max": 8192,
                 },
             },
@@ -282,14 +251,10 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "google": {
             "model_id": "gemini-1.5-flash-8b",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_output_tokens",
                     "default": PROVIDER_DEFAULT,
-                    # https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
                     "max": 8192,
                 },
             },
@@ -300,14 +265,10 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "google": {
             "model_id": "gemini-1.5-pro",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
                 "max_tokens": {
                     "custom_key": "max_output_tokens",
                     "default": PROVIDER_DEFAULT,
-                    # https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models#gemini-models
                     "max": 8192,
                 },
             },
@@ -318,14 +279,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "anthropic": {
             "model_id": "claude-3-5-sonnet-latest",
             "params": {
-                "temperature": {
-                    "default": 0.0,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": 1000,  # L2M2 default, field is required
-                    "max": 4096,
-                },
+                "temperature": {"default": 0.0, "max": 1.0},
+                "max_tokens": {"default": 1000, "max": 4096},
             },
             "extras": {},
         },
@@ -334,14 +289,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "anthropic": {
             "model_id": "claude-3-5-haiku-latest",
             "params": {
-                "temperature": {
-                    "default": 0.0,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": 1000,  # L2M2 default, field is required
-                    "max": 4096,
-                },
+                "temperature": {"default": 0.0, "max": 1.0},
+                "max_tokens": {"default": 1000, "max": 4096},
             },
             "extras": {},
         },
@@ -350,14 +299,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "anthropic": {
             "model_id": "claude-3-opus-20240229",
             "params": {
-                "temperature": {
-                    "default": 0.0,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": 1000,  # L2M2 default, field is required
-                    "max": 4096,
-                },
+                "temperature": {"default": 0.0, "max": 1.0},
+                "max_tokens": {"default": 1000, "max": 4096},
             },
             "extras": {},
         },
@@ -366,14 +309,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "anthropic": {
             "model_id": "claude-3-sonnet-20240229",
             "params": {
-                "temperature": {
-                    "default": 0.0,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": 1000,  # L2M2 default, field is required
-                    "max": 4096,
-                },
+                "temperature": {"default": 0.0, "max": 1.0},
+                "max_tokens": {"default": 1000, "max": 4096},
             },
             "extras": {},
         },
@@ -382,14 +319,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "anthropic": {
             "model_id": "claude-3-haiku-20240307",
             "params": {
-                "temperature": {
-                    "default": 0.0,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": 1000,  # L2M2 default, field is required
-                    "max": 4096,
-                },
+                "temperature": {"default": 0.0, "max": 1.0},
+                "max_tokens": {"default": 1000, "max": 4096},
             },
             "extras": {},
         },
@@ -398,14 +329,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "cohere": {
             "model_id": "command-r",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 4000,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 4000},
             },
             "extras": {},
         },
@@ -414,14 +339,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "cohere": {
             "model_id": "command-r-plus",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 4000,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 4000},
             },
             "extras": {},
         },
@@ -430,14 +349,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "mistral": {
             "model_id": "mistral-large-latest",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": INF,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": INF},
             },
             "extras": {"json_mode_arg": {"response_format": {"type": "json_object"}}},
         },
@@ -446,14 +359,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "mistral": {
             "model_id": "ministral-3b-latest",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": INF,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": INF},
             },
             "extras": {"json_mode_arg": {"response_format": {"type": "json_object"}}},
         },
@@ -462,14 +369,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "mistral": {
             "model_id": "ministral-8b-latest",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": INF,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": INF},
             },
             "extras": {"json_mode_arg": {"response_format": {"type": "json_object"}}},
         },
@@ -478,14 +379,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "mistral": {
             "model_id": "mistral-small-latest",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": INF,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": INF},
             },
             "extras": {"json_mode_arg": {"response_format": {"type": "json_object"}}},
         },
@@ -494,14 +389,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "mixtral-8x7b-32768",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**16 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**16 - 1},
             },
             "extras": {},
         },
@@ -510,14 +399,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "gemma2-9b-it",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**16 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**16 - 1},
             },
             "extras": {},
         },
@@ -526,24 +409,15 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama3-8b-8192",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**16 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**16 - 1},
             },
             "extras": {},
         },
         "replicate": {
             "model_id": "meta/meta-llama-3-8b-instruct",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 5.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 5.0},
                 "max_tokens": {
                     "custom_key": "max_new_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -557,24 +431,15 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama3-70b-8192",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**16 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**16 - 1},
             },
             "extras": {},
         },
         "replicate": {
             "model_id": "meta/meta-llama-3-70b-instruct",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 5.0,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 5.0},
                 "max_tokens": {
                     "custom_key": "max_new_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -588,28 +453,16 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama-3.1-8b-instant",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 8000,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 8000},
             },
             "extras": {},
         },
         "cerebras": {
             "model_id": "llama3.1-8b",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.5,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**31 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.5},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**31 - 1},
             },
             "extras": {},
         },
@@ -618,10 +471,7 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "replicate": {
             "model_id": "meta/meta-llama-3.1-405b-instruct",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": INF,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": INF},
                 "max_tokens": {
                     "custom_key": "max_new_tokens",
                     "default": PROVIDER_DEFAULT,
@@ -635,14 +485,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama-3.2-1b-preview",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**13,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**13},
             },
             "extras": {"preview": True},
         },
@@ -651,14 +495,8 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama-3.2-3b-preview",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**13,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**13},
             },
             "extras": {"preview": True},
         },
@@ -667,28 +505,16 @@ MODEL_INFO: Dict[str, Dict[str, ModelEntry]] = {
         "groq": {
             "model_id": "llama-3.3-70b-versatile",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2.0,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**15,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 2.0},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**15},
             },
             "extras": {"preview": True},
         },
         "cerebras": {
             "model_id": "llama3.3-70b",
             "params": {
-                "temperature": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 1.5,
-                },
-                "max_tokens": {
-                    "default": PROVIDER_DEFAULT,
-                    "max": 2**31 - 1,
-                },
+                "temperature": {"default": PROVIDER_DEFAULT, "max": 1.5},
+                "max_tokens": {"default": PROVIDER_DEFAULT, "max": 2**31 - 1},
             },
             "extras": {},
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-httpx>=0.27.0
-typing_extensions>=4.12.2
+httpx>=0.28.1


### PR DESCRIPTION
This PR removes the unnecessary typing_extensions dependency by refactoring model_info to only use standard python 3.9 types while preserving its type strength